### PR TITLE
add musl.m4

### DIFF
--- a/m4/musl.m4
+++ b/m4/musl.m4
@@ -1,0 +1,20 @@
+# musl.m4 serial 4
+dnl Copyright (C) 2019-2024 Free Software Foundation, Inc.
+dnl This file is free software; the Free Software Foundation
+dnl gives unlimited permission to copy and/or distribute it,
+dnl with or without modifications, as long as this notice is preserved.
+
+# Test for musl libc, despite the musl libc authors don't like it
+# <https://wiki.musl-libc.org/faq.html>
+# <https://lists.gnu.org/archive/html/bug-gnulib/2018-02/msg00079.html>.
+# From Bruno Haible.
+
+AC_DEFUN_ONCE([gl_MUSL_LIBC],
+[
+  AC_REQUIRE([AC_CANONICAL_HOST])
+  case "$host_os" in
+    *-musl* | midipix*)
+      AC_DEFINE([MUSL_LIBC], [1], [Define to 1 on musl libc.])
+      ;;
+  esac
+])


### PR DESCRIPTION
Add `musl.m4` (retrieved from https://git.savannah.gnu.org/gitweb/?p=gnulib.git;a=blob;f=m4/musl.m4;h=34d2c1ff22a148eeb76936410ac497d68b228f59;hb=HEAD)
`
musl.m4` is needed for `gl_MUSL_LIBC` since https://github.com/roswell/libsigsegv/commit/a6ff69873110c0a8ba6f7fd90532dbc11224828c